### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # LuCI support for Cloudflared
 
+> [!IMPORTANT]
+> The app was [merged into official OpenWrt packages feed](https://github.com/openwrt/luci/tree/master/applications/luci-app-cloudflared).
+> Now you can install it with `opkg update ; opkg install luci-app-cloudflared`
+> So the repository is deprecated
+
 ## Connection your OpenWrt with Cloudflared Zero Trust Tunnel via LuCI
 
 ![image](https://github.com/animegasan/luci-app-cloudflared/assets/14136053/228b8017-ac13-47de-8ca8-e5a919c8d93e)


### PR DESCRIPTION
> [!NOTE]
> The app was [merged into official OpenWrt packages feed](https://github.com/openwrt/luci/tree/master/applications/luci-app-cloudflared).
> Now you can install it with `opkg update ; opkg install luci-app-cloudflared`
> So the repository is deprecated

CC @tdzz8 @noobzhax @masjeho2 @ctvedt @xfreshmanx @huang207 @ilhamepri @rtaserver

You must be interested to try the app from official repo. If will be built soon and available for download.

@animegasan please archive the repo once merging the PR